### PR TITLE
Add Embed Option to pats2xhtml Utility

### DIFF
--- a/utils/atsyntax/DATS/pats2xhtml_main.dats
+++ b/utils/atsyntax/DATS/pats2xhtml_main.dats
@@ -456,6 +456,8 @@ process_cmdline2_COMARGkey2
         state.waitkind := WTKinput_dyn
     | "--output" =>
         state.waitkind := WTKoutput ()
+    | "--embed" =>
+        state.standalone := false
     | "--help" => let
         val () =
           state.waitkind := WTKnone ()


### PR DESCRIPTION
The embed flag is useful for the cross reference application that just expects a single div container with all the ATS syntax highlighted.
