### PR TITLE
Libats depends on libgmp, so the link order should be specified directly...

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -488,8 +488,10 @@ all:: patsopt
 
 ######
 
+# AS-20130407: libats depends on libgmp (hence specified earlier);
+# link order matters to GNU ld
 patsopt: pats_main_dats.o $(OBJECTS) ; \
-  $(ATSCC) $(ATSGCFLAG) $(ATSCCFLAGS) -o $@ pats_main_dats.o $(OBJECTS) -lgmp
+  $(ATSCC) $(ATSGCFLAG) $(ATSCCFLAGS) -o $@ pats_main_dats.o $(OBJECTS) -lats -lgmp
 cleanall:: ; $(RMF) patsopt
 
 ######

--- a/src/Makefile.atxt
+++ b/src/Makefile.atxt
@@ -510,8 +510,10 @@ all:: patsopt
 
 ######
 
+# AS-20130407: libats depends on libgmp (hence specified earlier);
+# link order matters to GNU ld
 patsopt: pats_main_dats.o $(OBJECTS) ; \\
-  $(ATSCC) $(ATSGCFLAG) $(ATSCCFLAGS) -o $@ pats_main_dats.o $(OBJECTS) -lgmp
+  $(ATSCC) $(ATSGCFLAG) $(ATSCCFLAGS) -o $@ pats_main_dats.o $(OBJECTS) -lats -lgmp
 cleanall:: ; $(RMF) patsopt
 
 ######


### PR DESCRIPTION
Building on Cygwin with GCC 4.7.2, [ld] complains about unresolved symbols (of GMP) in a file from [$ATSHOME/ccomp/lib/libats.a]. To fix, supply [-lats] flag explicitly after [-lgmp].
