### PR TITLE
A few fixes to atsmake

### DIFF
--- a/share/atsmake-post.mk
+++ b/share/atsmake-post.mk
@@ -4,8 +4,7 @@
 
 ######
 
-ifeq ("$(MYTARGET)","")
-else
+ifdef MYTARGET
 $(MYTARGET)_SATS_O := \
   $(patsubst %.sats, %_sats.o, $(SOURCES_SATS))
 $(MYTARGET)_DATS_O := \
@@ -14,9 +13,9 @@ endif
 
 ######
 
-ifeq ("$(MYTARGET)","")
+ifndef MYTARGET
 else
-ifeq ("$(MYTARGET)","MYTARGET")
+ifeq ($(strip $(MYTARGET)),MYTARGET)
 else
 all:: $(MYTARGET)
 $(MYTARGET): \
@@ -41,7 +40,7 @@ endif
 #
 # For compiling ATS source directly
 #
-ifeq ("$(MYCCRULE)","")
+ifndef MYCCRULE
 %_sats.o: %.sats ; \
   $(PATSCC) -cleanaft $(INCLUDE) $(INCLUDE_ATS) $(CFLAGS) -c $<
 %_dats.o: %.dats ; \
@@ -52,7 +51,7 @@ endif
 #
 # For compiling C code generated from ATS source
 #
-ifeq ("$(MYCCRULE)", "PORTABLE")
+ifeq ($(strip $(MYCCRULE)),PORTABLE)
 #
 CC=gcc
 #
@@ -65,8 +64,7 @@ endif
 #
 # For generating portable C code
 #
-ifeq ("$(MYPORTDIR)", "")
-else
+ifdef MYPORTDIR
 #
 $(MYPORTDIR)_SATS_C := \
   $(patsubst %.sats, $(MYPORTDIR)/%_sats.c, $(SOURCES_SATS))
@@ -87,13 +85,10 @@ endif
 #
 depend:: ; $(RMF) -f .depend
 #
-ifeq ("$(SOURCES_SATS)","")
-else
+ifdef SOURCES_SATS
 depend:: ; $(PATSOPT) --output-a .depend --depgen -s $(SOURCES_SATS)
 endif
-#
-ifeq ("$(SOURCES_DATS)","")
-else
+ifdef SOURCES_DATS
 depend:: ; $(PATSOPT) --output-a .depend --depgen -d $(SOURCES_DATS)
 endif
 #

--- a/share/atsmake-pre.mk
+++ b/share/atsmake-pre.mk
@@ -62,9 +62,4 @@ cleanall::
 
 ######
 
-SOURCES_SATS=
-SOURCES_DATS=
-
-######
-
 ###### end of [atsmake-pre.mk] ######


### PR DESCRIPTION
In general, the construction:

ifeq ("$(VAR)","VALUE")
...

doesn't work as expected; expansion of variables with whitespace can
cause problems. The solution is to do:

ifeq ($(strip $(VAR),VALUE))
...

which strips off any extra whitespace.

In the case where VALUE is the empty string, it makes more sense to
write:

ifndef VAR
...

Which results in many instances of the construction:

ifndef ...
else
...
endif

I changed this to:

ifdef
...
endif

I also removed the initial empty declarations of SOURCES_?ATS in
atsmake-pre.mk; This allows for the use of ifdef.

for more info, see:

https://gnu.org/software/make/manual/make.html#Conditional-Syntax
