### PR TITLE
linmap_insert: needs !wrt?

### DIFF
--- a/doc/EXAMPLE/ATSLIB/libats_linset_listord.dats
+++ b/doc/EXAMPLE/ATSLIB/libats_linset_listord.dats
@@ -57,37 +57,6 @@ val () = linset_free (xs)
 //
 } // end of [val]
 
-val () = {
-val n = 10
-val n2 = n/2
-val () = assertloc (n > 0)
-
-var ints1: set (int) = linset_make_nil ()
-var i: int; val () =
-  for (i := 0; i < n2; i := i+1) {
-    val _ = linset_insert<int> (ints1, i)
-  } (* end of [for] *)
-// end [val]
-val size1 = linset_size (ints1)
-val () = println! ("size1 = ", size1)
-
-var ints2: set (int) = linset_make_nil ()
-var i: int; val () =
-  for (i := n2; i < n + n/2; i := i+1) {
-    val _ = linset_insert<int> (ints2, i)
-  } (* end of [for] *)
-// end [val]
-val size2 = linset_size (ints2)
-val () = println! ("size2 = ", size2)
-
-val ints_union = linset_union (ints1, ints2)
-val size = linset_size (ints_union)
-val () = println! ("size(ints_union) = ", size)
-val () = linset_free (ints_union)
-//
-} // end of [val]
-
-
 (* ****** ****** *)
 
 val () =


### PR DESCRIPTION
I seem to need this in certain code for it to typecheck.

It seems to make sense that an insert function would require !wrt.

What is more confusing, if I typecheck the relevant example in  doc/EXAMPLE/ATSLIB, this seems to be unnecessary.
