### PR TITLE
initial interface for grcnf_minmean_std using clorefs

### DIFF
--- a/doc/PROJECT/TEMPORARY/FALCON/falcon.sats
+++ b/doc/PROJECT/TEMPORARY/FALCON/falcon.sats
@@ -57,9 +57,17 @@ overload fprint with fprint_position
 //
 (* ****** ****** *)
 
+#define NAN 0.0/0.0
+macdef INF = $extval (double, "INFINITY")
+
+(* ****** ****** *)
+
 fun position_get_now (): position
 
 (* ****** ****** *)
+abstype expvar_type = ptr
+typedef expvar = expvar_type
+vtypedef listvt_expvar = [n:nat] list_vt(expvar, n)
 //
 abstype gene_type = ptr
 typedef gene = gene_type
@@ -87,6 +95,13 @@ fun gene_make_symbol (symbol): gene
 *)
 absvtype genes_vtype = ptr
 vtypedef genes = genes_vtype
+vtypedef geneslst = List0_vt (genes)
+
+(* ****** ****** *)
+
+absvtype grcnf = ptr
+vtypedef 
+grcnflst = List0_vt (grcnf)
 
 (* ****** ****** *)
 

--- a/doc/PROJECT/TEMPORARY/FALCON/falcon_algorithm1.dats
+++ b/doc/PROJECT/TEMPORARY/FALCON/falcon_algorithm1.dats
@@ -79,9 +79,37 @@ end // end of [genelst_min]
 (* ****** ****** *)
 
 extern
+fun
+grcnf_minmean_std(
+  cnf: !grcnf, GDMapclo: (!genes) -<cloref1> expvar
+): expvar
+//
+extern
+fun
+grcnflst_minmean_std(
+  cnfs: !grcnflst, GDMapclo: (!genes) -<cloref1> expvar
+): List0_vt(expvar)
+
+(* ****** ****** *)
+
+extern
 fun genes_meanvar
-  (xs: !genes, emap: GDMap, smap: GDMap): (double, double)
+  (xs: !genes, emap: GDMap, smap: GDMap): expvar
 // end of [genelst_meanvar]
+
+(* ****** ****** *)
+
+local
+
+assume
+grcnf = geneslst
+//
+assume
+expvar_type = (double, double) // Not sure how to do this
+
+in (* in-of-local *)
+
+(* ****** ****** *)
 
 implement
 genes_meanvar
@@ -155,6 +183,53 @@ if nxs2 > 0
   then (nxs*(csum/nxs2), cvar) else (0.0, 0.0)
 // end of [if]
 end // end of [genes_meanvar]
+
+(* ****** ****** *)
+
+extern
+fun gmeanvar_makeclo(GDMap, GDMap):  
+  (!genes) -<cloref1> expvar
+//
+implement
+gmeanvar_makeclo(emap, smap) =
+  lam(xs) => genes_meanvar(xs, emap, smap)
+
+(* ****** ****** *)
+
+implement
+grcnf_minmean_std(cnf, GDMapclo): expvar = let
+  val eval_svals = list_vt_map_cloref<genes><expvar> (cnf, GDMapclo)
+  // 
+  fun min_first_loop
+  (
+    xs: !listvt_expvar, current_min: expvar
+  ): expvar = case+ xs of
+  | list_vt_nil () => (NAN, NAN)
+  | list_vt_cons(x, xs1) => let
+      val current_min = if current_min.0 < x.0 then
+        current_min
+      else
+        x
+    in
+      min_first_loop(xs1, current_min)
+    end
+  // end of [min_first_loop]
+  val emin_s = min_first_loop(eval_svals, (INF, NAN))
+  val () = list_vt_free(eval_svals)
+in 
+  (emin_s.0, $M.sqrt(emin_s.1))
+end
+
+end (* end-of-local *)
+
+(* ****** ****** *)
+
+implement
+grcnflst_minmean_std(cnfs, GDMapclo) = 
+  list_vt_map_fun<grcnf><expvar> (
+    cnfs, 
+    lam(cnf) => grcnf_minmean_std(cnf, GDMapclo)
+  )
 
 (* ****** ****** *)
 

--- a/doc/PROJECT/TEMPORARY/FALCON/falcon_cnfize.dats
+++ b/doc/PROJECT/TEMPORARY/FALCON/falcon_cnfize.dats
@@ -23,33 +23,18 @@ staload "./falcon_parser.dats"
 staload
 UN = "prelude/SATS/unsafe.sats"
 
-(* ****** ****** *)
-
-vtypedef
-grcnf = geneslst
-vtypedef 
-grcnflst = List0_vt (grcnf)
+staload 
+M = "libc/SATS/math.sats"
 
 (* ****** ****** *)
 
 extern
 fun grcnf_free (grcnf): void
-//
-implement
-grcnf_free (xs) =
-(
-case+ xs of
-| ~list_vt_nil () => ()
-| ~list_vt_cons (x, xs) => (genes_free (x); grcnf_free (xs))
-) (* end of [grcnf_free] *)
 
 (* ****** ****** *)
 
 extern
 fun grcnf_make_nil(): grcnf
-//
-implement
-grcnf_make_nil() = nil_vt
 
 (* ****** ****** *)
 
@@ -73,23 +58,7 @@ fprint_grcnf (FILEref, !grcnf): void
 extern
 fun
 fprint_grcnflst (FILEref, !grcnflst): void  
-
-(* ****** ****** *)
-
-local
-//
-implement
-fprint_ref<genes>
-  (out, xs) = fprint_genes (out, xs)
-//
-in(*in-of-local*)
-//
-implement
-fprint_grcnf (out, cnf) =
-  fprint_list_vt_sep<genes> (out, cnf, "; ")
-//
-end // end of [local]
-  
+ 
 (* ****** ****** *)
 
 implement
@@ -134,6 +103,50 @@ fun
 grcnf_conj
   (cnfs: grcnflst): geneslst
 //
+extern
+fun
+grcnf_disj
+  (cnfs: grcnflst): geneslst
+//
+
+(* ****** ****** *)
+
+local
+
+assume
+grcnf = geneslst
+
+in (* in-of-local *)
+
+implement
+grcnf_free (xs) =
+(
+case+ xs of
+| ~list_vt_nil () => ()
+| ~list_vt_cons (x, xs) => (genes_free (x); grcnf_free (xs))
+) (* end of [grcnf_free] *)
+
+implement
+grcnf_make_nil() = nil_vt
+
+(* ****** ****** *)
+
+local
+//
+implement
+fprint_ref<genes>
+  (out, xs) = fprint_genes (out, xs)
+//
+in(*in-of-local*)
+//
+implement
+fprint_grcnf (out, cnf) =
+  fprint_list_vt_sep<genes> (out, cnf, "; ")
+//
+end // end of [local]
+
+(* ****** ****** *)
+
 implement
 grcnf_conj (cnfs) = let
 //
@@ -165,11 +178,6 @@ case+ cnfs of
 end // end of [grcnf_conj]
 
 (* ****** ****** *)
-//
-extern
-fun
-grcnf_disj
-  (cnfs: grcnflst): geneslst
 //
 implement
 grcnf_disj (cnfs) = let
@@ -281,7 +289,7 @@ fun auxsub
     end (* end of [list_vt_cons] *)
 ) (* end of [auxsub] *)
 
-in (* in-of-local *)
+in (* in-of-local (geneslst_cons)*)
 
 implement
 geneslst_cons
@@ -380,12 +388,13 @@ case+ gx of
 //
 end // end of [grexp_cnfize]
 
+end (* end-of-local *)
+
 (* ****** ****** *)
-//
+
 implement
 grexplst_cnfize (gxs) =
   list_map_fun<grexp><grcnf> (gxs, grexp_cnfize)
-//
-(* ****** ****** *)
+
 
 (* end of [falcon_cnfize.dats] *)

--- a/doc/PROJECT/TEMPORARY/FALCON/falcon_genes.dats
+++ b/doc/PROJECT/TEMPORARY/FALCON/falcon_genes.dats
@@ -131,8 +131,8 @@ end // end of [local]
 
 (* ****** ****** *)
 
-vtypedef
-geneslst = List0_vt (genes)
+//vtypedef
+//geneslst = List0_vt (genes)
 (* ****** ****** *)
 
 extern

--- a/doc/PROJECT/TEMPORARY/FALCON/falcon_gmeanvar.dats
+++ b/doc/PROJECT/TEMPORARY/FALCON/falcon_gmeanvar.dats
@@ -33,6 +33,16 @@ staload "./falcon_tokener.dats"
 
 (* ****** ****** *)
 
+(* This function is the primary interface to use to read gene *)
+(* expression data. It returns a pair of Maps that return the *)
+(* expression level and standard deviation of expression for  *)
+(* the gene under consideration.                              *)
+
+extern
+fun gmeanvar_initize (inp: FILEref): (GDMap, GDMap)
+
+(* ****** ****** *)
+
 extern
 fun gene_read
   (inp: &string >> ptr): Strptr1
@@ -90,13 +100,13 @@ end // end of [mean_read]
 (* ****** ****** *)
 
 extern
-fun variance_read (inp: &string >> ptr): double
+fun stdev_read (inp: &string >> ptr): double
 implement
-variance_read
+stdev_read
   (inp) = let
   val str = inp
   prval () = topize (inp) in $STDLIB.strtod1 (str, inp)
-end // end of [variance_read]
+end // end of [stdev_read]
 
 (* ****** ****** *)
 
@@ -167,7 +177,7 @@ GDMap_insert (map, gn, gval) =
 (* ****** ****** *)
 
 val the_GDMap_mean = hashtbl_make_nil<key,itm> (i2sz(1024))
-val the_GDMap_variance = hashtbl_make_nil<key,itm> (i2sz(1024))
+val the_GDMap_stdev = hashtbl_make_nil<key,itm> (i2sz(1024))
 
 (* ****** ****** *)
 
@@ -191,7 +201,7 @@ if line = line0 then nerr := nerr + 1
 //
 val line0 = line
 val () = line := $UN.cast{string}(line)
-val variance = variance_read (line)
+val stdev = stdev_read (line)
 val () =
 if line = line0 then nerr := nerr + 1
 //
@@ -201,26 +211,16 @@ val gene = gene_make_name(strptr2string(gene))
 val () =
 if nerr = 0 then println! ("gmeanvar_read: ", gene, " -> ", mean)
 val () =
-if nerr = 0 then println! ("gmeanvar_read: ", gene, " -> ", variance)
+if nerr = 0 then println! ("gmeanvar_read: ", gene, " -> ", stdev)
 *)
 //
 val () =
 if nerr = 0 then GDMap_insert (the_GDMap_mean, gene, mean)
 val () =
-if nerr = 0 then GDMap_insert (the_GDMap_variance, gene, variance)
+if nerr = 0 then GDMap_insert (the_GDMap_stdev, gene, stdev)
 //
 in
 end // end of [gmeanvar_read]
-
-(* ****** ****** *)
-
-end // end of [local]
-
-
-(* ****** ****** *)
-
-extern
-fun gmeanvar_initize (inp: FILEref): void
 
 (* ****** ****** *)
 
@@ -252,8 +252,10 @@ val ((*void*)) = loop (sbf)
 val () = stringbuf_free (sbf)
 //
 in
-  // nothing  
+  (the_GDMap_mean, the_GDMap_stdev)
 end // end of [gmeanvar_initize]
+
+end // end of [local]
 
 (* ****** ****** *)
 

--- a/doc/PROJECT/TEMPORARY/FALCON/falcon_main.dats
+++ b/doc/PROJECT/TEMPORARY/FALCON/falcon_main.dats
@@ -166,6 +166,13 @@ falcon_rules_data_skipped
 val out = stdout_ref
 //
 val opt =
+fileref_open_opt (data_file, file_mode_r)
+val-~Some_vt(inp) = opt
+//
+val (emap, smap) = gmeanvar_initize(inp)
+val GDMapclo = gmeanvar_makeclo(emap, smap)
+//
+val opt =
 fileref_open_opt (rule_file, file_mode_r)
 val-~Some_vt(inp) = opt
 //
@@ -189,10 +196,16 @@ val () = print ("pos(final) = ")
 val () = fprint_the_position (out)
 val () = print_newline ((*void*))
 //
-val rec2cnfs =
+val cnfs =
   grexplst_cnfize_ifnot (gxs, skipped)
 //
-val ((*freed*)) = grcnflst_free (rec2cnfs)
+val expvars = grcnflst_minmean_std(cnfs, GDMapclo)
+//
+val () = fprint! (out, "enzyme abundance =\n")
+val () = fprint! (out, expvars)
+//
+val ((*freed*)) = grcnflst_free (cnfs)
+val ((*freed*)) = list_vt_free (expvars)
 } (* end of [falcon_rules_data_skipped] *)
 
 implement


### PR DESCRIPTION
This should be working, but I wasn't sure how to correctly abstract expvar. Also, I've added a couple of changes to list.sats that you may or may not want to use as is; I can take a crack at implementing them if you like.

Squashed commits:

---

minor changes

makeclo interface working

grcnf_minmean_std typechecks

tidying up a bit

implemented min_first_loop and simplified

complete test of algorithm typechecks but doesn't compile

reorganized a bit

changed expvar to an abstract type, but this isn't quite working
