### PR TITLE
include default input and output as currently used by FALCON MATLAB scripts

### DIFF
--- a/doc/PROJECT/TEMPORARY/FALCON/falcon_cmdline.dats
+++ b/doc/PROJECT/TEMPORARY/FALCON/falcon_cmdline.dats
@@ -15,5 +15,68 @@ staload "./falcon.sats"
   
 (* ****** ****** *)
 
+staload "./falcon_parser.dats"
+staload "./falcon_cnfize.dats"
+staload "./falcon_cnfize_ifnot.dats"
+
+(* ****** ****** *)
+
+dynload "./falcon.sats"
+dynload "./falcon_symbol.dats"
+dynload "./falcon_position.dats"
+dynload "./falcon_tokener.dats"
+dynload "./falcon_genes.dats"
+dynload "./falcon_parser.dats"
+dynload "./falcon_cnfize.dats"
+dynload "./falcon_cnfize_ifnot.dats"
+dynload "./falcon_expvar.dats"
+dynload "./falcon_gmeanvar.dats"
+dynload "./falcon_algorithm1.dats"
+
+(* ****** ****** *)
+
+// For now just include default output as currently
+// used by MATLAB scripts.
+
+implement
+fprint_expvar (out, x) =
+  fprint! (out, x.gexp, "\t", x.gvar)
+
+implement 
+main0 {n} (argc, argv) = 
+{
+//
+val out = stdout_ref
+//
+val () = assertloc(argc = 3)
+val expInFi = argv[1]
+val rulesInFi = argv[2]
+//
+val opt =
+fileref_open_opt (expInFi, file_mode_r)
+val-~Some_vt(inp) = opt
+//
+val (emap, smap) = gmeanvar_initize(inp)
+val ((*void*)) = fileref_close (inp)
+//
+val opt =
+fileref_open_opt (rulesInFi, file_mode_r)
+val-~Some_vt(inp) = opt
+//
+val gxs = parse_fileref (inp)
+val ((*void*)) = fileref_close (inp)
+//
+val skipped = ruleset_make_nil ()
+val grcnfs =
+grexplst_cnfize_ifnot (gxs, skipped)
+//
+val expvars =
+grcnflst_minmean_stdev (grcnfs, emap, smap)
+//
+val () = fprint_list_vt_sep (out, expvars, "\n")
+//
+val ((*freed*)) = list_vt_free (expvars)
+val ((*freed*)) = grcnflst_free (grcnfs)
+}
 (* end of [falcon_cmdline.dats] *)
 


### PR DESCRIPTION
(currently only tested to typecheck)
