### PR TITLE
Delete install command's -T option.

### DIFF
--- a/doc/DISTRIB/ATS-Postiats/Makefile_dist
+++ b/doc/DISTRIB/ATS-Postiats/Makefile_dist
@@ -103,13 +103,13 @@ install_files_0: install_dirs ; \
   done
 
 install_files_1: bin/patscc ; \
-  $(INSTALL) -T -m 755 $< $(PATSLIBHOME2)/bin/patscc && echo $<
+  $(INSTALL) -m 755 $< $(PATSLIBHOME2)/bin/patscc && echo $<
 install_files_2: bin/patsopt ; \
-  $(INSTALL) -T -m 755 $< $(PATSLIBHOME2)/bin/patsopt && echo $<
+  $(INSTALL) -m 755 $< $(PATSLIBHOME2)/bin/patsopt && echo $<
 install_files_3: bin/patscc_env.sh ; \
-  $(INSTALL) -T -m 755 $< $(bindir2)/patscc && echo $<
+  $(INSTALL) -m 755 $< $(bindir2)/patscc && echo $<
 install_files_4: bin/patsopt_env.sh ; \
-  $(INSTALL) -T -m 755 $< $(bindir2)/patsopt && echo $<
+  $(INSTALL) -m 755 $< $(bindir2)/patsopt && echo $<
 
 install_files_5: ; \
   for f in \
@@ -117,7 +117,7 @@ install_files_5: ; \
     ccomp/atslib/lib64/libatslib.a ; \
   do \
     if [ -e "$$f" ] ; then \
-      $(INSTALL) -T -m 755 "$$f" $(PATSLIBHOME2)/"$$f" && echo "$$f"; \
+      $(INSTALL) -m 755 "$$f" $(PATSLIBHOME2)/"$$f" && echo "$$f"; \
     fi; \
   done
 


### PR DESCRIPTION
Because Mac OS X install command has no -T option.

```
$ install -T
install: illegal option -- T
usage: install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 file2
       install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 ... fileN directory
       install -d [-v] [-g group] [-m mode] [-o owner] directory ...
```
