### PR TITLE
Adding Extra Information to Static Expressions Export

### DIFF
--- a/src/pats_staexp2.sats
+++ b/src/pats_staexp2.sats
@@ -1443,6 +1443,8 @@ fun jsonize_s2exp (flag: int, s2e: s2exp): jsonval
 fun jsonize_s2explst (flag: int, s2es: s2explst): jsonval
 fun jsonize_s2expopt (flag: int, s2eopt: s2expopt): jsonval
 //
+fun jsonize_s2zexp (s2e: s2zexp): jsonval
+//
 fun jsonize_labs2explst (flag: int, ls2es: labs2explst): jsonval  
 //
 fun jsonize_s2eff (s2fe: s2eff): jsonval


### PR DESCRIPTION
These changes are all that were needed to support an external constraint solver. It includes:
- Class information is added to s2 constants.
- Sorts are no longer exported as just strings. Instead, we export the constructors. This was done because an external constraint solver needs the type signature of a function. If support was added for tuples, we'd need this extra info as well. 
- Unification variables have a szexp associated with them. We export that information because sometimes it can be useful for the solver.
- S2Etop constructor is supported. We encounter this constructor a lot when parsing static calls to sizeof.  
