### PR TITLE
Cygwin and time_t

### DIFF
--- a/libats/DATS/linmap_skiplist.dats
+++ b/libats/DATS/linmap_skiplist.dats
@@ -56,6 +56,7 @@ stadef mytkind = $extkind"atslib_linmap_skiplist"
 (* ****** ****** *)
 
 %{^
+#include <time.h>
 extern void srand48 (time_t) ; // stdlib.h
 %}
 typedef time_t = $extype"time_t"


### PR DESCRIPTION
This fixes a compile issue on Cygwin (the patch also has been tested successfully on Linux):

```
ar -r lib/libatslib.a output/atslib_libats_funmap_avltree_dats.o
ar -r lib/libatslib.a output/atslib_libats_fundeque_fngtree_dats.o
ar -r lib/libatslib.a output/atslib_libats_funralist_nested_dats.o
ar -r lib/libatslib.a output/atslib_libats_linmap_list_dats.o
ar -r lib/libatslib.a output/atslib_libats_linmap_randbst_dats.o
\
  gcc -I"/home/brand_000/ATS-Postiats" -I"/home/brand_000/ATS-Postiats"/ccomp/runtime  -fPIC -O2 -c -o output/atslib_libats_linmap_skiplist_dats.o output/atslib_libats_linmap_skiplist_dats.c
output/atslib_libats_linmap_skiplist_dats.c:1:0: warning: -fPIC ignored for target (all code is position independent) [enabled by default]
 /*
 ^
output/atslib_libats_linmap_skiplist_dats.c:88:13: error: conflicting types for ‘time’
 extern lint time (void*) ; // time.h
             ^
In file included from /usr/include/setjmp.h:9:0,
                 from /home/brand_000/ATS-Postiats/ccomp/runtime/pats_ccomp_exception.h:46,
                 from output/atslib_libats_linmap_skiplist_dats.c:19:
/usr/include/time.h:53:11: note: previous declaration of ‘time’ was here
 time_t    _EXFUN(time,     (time_t *_timer));
           ^
Makefile:259: recipe for target 'output/atslib_libats_linmap_skiplist_dats.o' failed
make[1]: *** [output/atslib_libats_linmap_skiplist_dats.o] Error 1
make[1]: Leaving directory '/home/brand_000/ATS-Postiats/ccomp/atslib'
Makefile_devl:51: recipe for target 'atslib_update' failed
make: *** [atslib_update] Error 2
```
