### PR TITLE
Added a helper function in pats_util.dats

### DIFF
--- a/src/pats_utils.dats
+++ b/src/pats_utils.dats
@@ -53,6 +53,16 @@ static char *patsopt_PATSHOMERELOC = (char*)0 ;
 static char *patsopt_ATSPKGRELOCROOT = (char*)0 ;
 extern char *getenv (const char *name) ; // [stdlib.h]
 //
+ATSinline()
+ats_ptr_type
+patsopt_getenv(ats_ptr_type name) {
+  const char *v = getenv((const char *)name);
+  if (!v) {
+    return NULL;
+  }
+  return strdup (v);
+} // end of [patsopt_getenv]
+//
 ATSextfun()
 ats_ptr_type
 patsopt_PATSHOME_get () {
@@ -67,15 +77,15 @@ patsopt_PATSHOMERELOC_get () {
 ATSextfun()
 ats_void_type
 patsopt_PATSHOME_set () {
-  patsopt_PATSHOME = getenv ("PATSHOME") ;
+  patsopt_PATSHOME = patsopt_getenv ("PATSHOME") ;
   if (!patsopt_PATSHOME) patsopt_PATSHOME = getenv ("ATSHOME") ;
   return ;
 } // end of [patsopt_PATSHOME_set]
 ATSextfun()
 ats_void_type
 patsopt_PATSHOMERELOC_set () {
-  patsopt_PATSHOMERELOC = getenv ("PATSHOMERELOC") ;
-  if (!patsopt_PATSHOMERELOC) patsopt_PATSHOMERELOC = getenv ("ATSHOMERELOC") ;
+  patsopt_PATSHOMERELOC = patsopt_getenv ("PATSHOMERELOC") ;
+  if (!patsopt_PATSHOMERELOC) patsopt_PATSHOMERELOC = patsopt_getenv ("ATSHOMERELOC") ;
   return ;
 } // end of [patsopt_PATSHOMERELOC_set]
 //
@@ -87,7 +97,7 @@ patsopt_ATSPKGRELOCROOT_get () {
 ATSextfun()
 ats_void_type
 patsopt_ATSPKGRELOCROOT_set () {
-  patsopt_ATSPKGRELOCROOT = getenv ("ATSPKGRELOCROOT") ; return ;
+  patsopt_ATSPKGRELOCROOT = patsopt_getenv ("ATSPKGRELOCROOT") ; return ;
 } // end of [patsopt_ATSPKGRELOCROOT_set]
 //
 %} (* end of [%{^] *)


### PR DESCRIPTION
This helper function copies the return string from getenv so that libc cannot trash our pointers to environment variables. For example, emscripten's libc keeps a single buffer to store the string referred to by getenv's return value. When you call getenv again, it frees the previous string and allocates space for a new one. 

This is acceptable from the standard's point of view, so we might want to make our own copy of the environment variables we fetch. This approach may cause a memory leak, but we store all pointers
returned from getenv as global variables in patsopt.
