### PR TITLE
ATS min variable

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,9 @@ GCFLAG=-D_ATS_GCATS
 # [gmpknd] for CBOOT
 # [intknd] for CBOOTmin
 #
-C3NSTRINTKND=gmpknd
+ifndef C3NSTRINTKND
+  C3NSTRINTKND=gmpknd
+endif
 #
 ######
 


### PR DESCRIPTION
Making it easier to select ATSmin without needing to modify the Makefile tracked by git. If accepted, I can update wiki instructions.
