### PR TITLE
adding a basic check for windows absolute paths

### DIFF
--- a/src/pats_filename.dats
+++ b/src/pats_filename.dats
@@ -273,7 +273,12 @@ givename_is_relative
   (
     given: string n, i: size_t i, dirsep: char
   ) : bool =
-    if string_isnot_atend (given, i) then (given[i] != dirsep) else false 
+    if string_isnot_atend (given, i) then 
+    (
+      if (given[i] = dirsep) then false
+      else if string_isnot_atend (given, i+1) 
+        then (given[i+1] != ':') else true
+    ) else false 
   // end of [aux]
   val dirsep = theDirSep_get ()
   val given = string1_of_string (given)


### PR DESCRIPTION
I see what you mean about ATS getting confused by the path name, but I don't quite follow the [symlink suggestion](https://groups.google.com/d/msg/ats-lang-users/BoEWYOCGR9E/QRPxzMdbKk8J).

This is an apparent fix; I tested it and the error is no longer there, but please check the logic in case I missed something.

It is less of a dirty hack, but still a dirty hack - but that is the situation we are in if we want to use a Cygwin program from outside of Cygwin.
