### PR TITLE
Try to build utils/atsynmark on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,8 @@ script:
   - make -f Makefile_devl all
   - make -C ${PATSHOME}/doc regress > regress_doc.log 2>&1
   - tail -100 regress_doc.log
+  # Build utils
+  - make -C libatsynmark
+  - make -C utils/atsynmark
 after_script:
   - date


### PR DESCRIPTION
Try to build utils/atsynmark on Travis-CI.
However, following error occurs... https://travis-ci.org/master-q/ATS-Postiats/builds/44021263

```
/home/travis/ats-lang-anairiats-0.2.11/bin/atsopt -IATS /home/travis/build/master-q/ATS-Postiats -IATS /home/travis/ats-lang-anairiats-0.2.11 --output pats2xhtml_level1_dats.c --dynamic DATS/pats2xhtml_level1.dats
gcc -I/home/travis/ats-lang-anairiats-0.2.11/ccomp/runtime/ -I/home/travis/ats-lang-anairiats-0.2.11/ -I /home/travis/build/master-q/ATS-Postiats/src -c pats2xhtml_level1_dats.c 
\
  "/home/travis/ats-lang-anairiats-0.2.11"/bin/atscc -O2 -I "/home/travis/build/master-q/ATS-Postiats"/src -IATS "/home/travis/build/master-q/ATS-Postiats" -IATS "/home/travis/ats-lang-anairiats-0.2.11" -o pats2xhtml DATS/pats2xhtml_main.dats pats_utils_sats.o pats_utils_dats.o pats_global_sats.o pats_global_dats.o pats_errmsg_sats.o pats_errmsg_dats.o pats_comarg_sats.o pats_comarg_dats.o pats_symbol_dats.o pats_filename_dats.o pats_intinf_sats.o pats_effect_sats.o pats_effect_dats.o pats_symmap_sats.o pats_symmap_dats.o pats_symenv_sats.o pats_symenv_dats.o pats_staexp1_sats.o pats_staexp1_dats.o pats_dynexp1_sats.o pats_trans1_sats.o pats_trans1_env_sats.o pats_trans1_env_dats.o pats_trans1_error_dats.o pats_trans1_e0xp_dats.o pats2xhtml_sats.o pats2xhtml_level1_dats.o  -L /home/travis/build/master-q/ATS-Postiats/libatsynmark -latsynmark -lgmp
/home/travis/ats-lang-anairiats-0.2.11/bin/atsopt -IATS /home/travis/build/master-q/ATS-Postiats -IATS /home/travis/ats-lang-anairiats-0.2.11 --output pats2xhtml_main_dats.c --dynamic DATS/pats2xhtml_main.dats
gcc -I/home/travis/ats-lang-anairiats-0.2.11/ -I/home/travis/ats-lang-anairiats-0.2.11/ccomp/runtime/ -L/home/travis/ats-lang-anairiats-0.2.11/ccomp/lib64/ /home/travis/ats-lang-anairiats-0.2.11/ccomp/runtime/ats_prelude.c -O2 -I /home/travis/build/master-q/ATS-Postiats/src -o pats2xhtml pats2xhtml_main_dats.c pats_utils_sats.o pats_utils_dats.o pats_global_sats.o pats_global_dats.o pats_errmsg_sats.o pats_errmsg_dats.o pats_comarg_sats.o pats_comarg_dats.o pats_symbol_dats.o pats_filename_dats.o pats_intinf_sats.o pats_effect_sats.o pats_effect_dats.o pats_symmap_sats.o pats_symmap_dats.o pats_symenv_sats.o pats_symenv_dats.o pats_staexp1_sats.o pats_staexp1_dats.o pats_dynexp1_sats.o pats_trans1_sats.o pats_trans1_env_sats.o pats_trans1_env_dats.o pats_trans1_error_dats.o pats_trans1_e0xp_dats.o pats2xhtml_sats.o pats2xhtml_level1_dats.o -L /home/travis/build/master-q/ATS-Postiats/libatsynmark -latsynmark -lgmp -lats 
pats_trans1_e0xp_dats.o: In function `aux_item_16':
pats_trans1_e0xp_dats.c:(.text+0x5ff): undefined reference to `_2home_2travis_2build_2master_2dq_2ATS_2dPostiats_2src_2pats_e1xpval_2esats__e1xp_valize'
pats_trans1_e0xp_dats.o: In function `_2home_2travis_2build_2master_2dq_2ATS_2dPostiats_2src_2pats_trans1_e0xp_2edats__staload':
pats_trans1_e0xp_dats.c:(.text+0xb1f): undefined reference to `_2home_2travis_2build_2master_2dq_2ATS_2dPostiats_2src_2pats_e1xpval_2esats__staload'
collect2: ld returned 1 exit status
Exit: [gcc] failed.
make: *** [pats2xhtml] Error 1
make: Leaving directory `/home/travis/build/master-q/ATS-Postiats/utils/atsynmark'
```
