### PR TITLE
Normalize S2 Expressions Before They Are Stored in Environment

### DIFF
--- a/src/pats_staexp2_appenv.hats
+++ b/src/pats_staexp2_appenv.hats
@@ -44,6 +44,10 @@
 staload "./pats_staexp2.sats"
 
 (* ****** ****** *)
+
+staload "./pats_staexp2_util.sats"
+
+(* ****** ****** *)
 //
 extern
 fun{}
@@ -114,6 +118,8 @@ implement
 {}(*tmp*)
 s2exp_app
   (s2e0, env) = let
+      val s2f0 = s2exp2hnf (s2e0)
+      val s2e0 = s2hnf2exp (s2f0)
 in
 //
 case+


### PR DESCRIPTION
All s2 expressions are normalized when constraints are exported. We should normalize s2 expressions when we build the s2cstmap and s2varmap so that all constants in normalized constraints are stored in the map. 

Without normalizing, I found some s2 constants can be missing from the s2cstmap.
