### PR TITLE
Add lack packages for OSX

### DIFF
--- a/travis-ci/installpkg.sh
+++ b/travis-ci/installpkg.sh
@@ -21,6 +21,9 @@ then
   brew install bdw-gc
 # brew install gtk+3
   brew install libev
+  brew install cairo
+  brew install pcre
+  brew install glib
   brew install jansson
 #
 fi


### PR DESCRIPTION
It seems to be lack of `cairo`, `pcre` and `glib` packages to install with Homebrew.
`pkg-config` for `gtk+3` dose not work correctly without `XQuartz`.
For now, I didn't include revert comment out commit for `gtk+3` and `gmp`.