### PR TITLE
added folder entry

### DIFF
--- a/share/HATS/atspre_define_pkgreloc.hats
+++ b/share/HATS/atspre_define_pkgreloc.hats
@@ -163,6 +163,10 @@ LIBATS_HWXI_sourceloc "$ATSLANGWEBLIB/contrib/libats-/hwxi"
 LIBATS_HWXI_targetloc "$PATSHOMERELOC/contrib/libats-/hwxi"
 //
 (* ****** ****** *)
+#define
+LIBATSBBARKER_targetloc "$PATSHOMERELOC/contrib/libats-/bbarker"
+//
+(* ****** ****** *)
 //
 // For applying ATS to AVR programming
 //


### PR DESCRIPTION
Is this encouraged or should we just stick with using 

```ocaml
"{$PATSHOMERELOC}/../.."
```

from here on? I actually prefer the latter but I noticed that using the shortcut `"{$LIBATSHWXI}/.."` is still in common use.