### PR TITLE
Fixed spelling error

### DIFF
--- a/src/pats_comarg.dats
+++ b/src/pats_comarg.dats
@@ -133,7 +133,7 @@ end // end of [comarglst_parse]
 
 implement
 comarg_warning (str) = {
-  val () = prerr ("waring(ATS)")
+  val () = prerr ("warning(ATS)")
   val () = prerr (": unrecognized command line argument [")
   val () = prerr (str)
   val () = prerr ("] is ignored.")


### PR DESCRIPTION
It’s a small error, but I see it whenever I make a mistake on the command line (which is often).