### PR TITLE
Static array t0ype

### DIFF
--- a/ccomp/runtime/pats_ccomp_typedefs.h
+++ b/ccomp/runtime/pats_ccomp_typedefs.h
@@ -116,6 +116,10 @@ typedef void* atstype_datconptr ;
 ** HX: for [datcontyp]
 */
 typedef void* atstype_datcontyp ;
+/*
+** AS: for arrays
+*/
+#define atstyarr_type(T)
 
 /* ****** ****** */
 

--- a/doc/EXAMPLE/TESTATS/Makefile
+++ b/doc/EXAMPLE/TESTATS/Makefile
@@ -79,6 +79,15 @@ cleanall:: ; $(RMF) fieldarr
 ######
 
 all:: \
+fieldarr2
+fieldarr2: fieldarr2.dats ; \
+  $(PATSCC2) -DATS_MEMALLOC_LIBC -cleanaft -o $@ $<
+regress:: fieldarr2 ; ./$<
+cleanall:: ; $(RMF) fieldarr2
+
+######
+
+all:: \
 findexn
 findexn: findexn_dats.c ; \
   $(PATSCC2) -D_GNU_SOURCE -DATS_MEMALLOC_LIBC -o $@ $<

--- a/doc/EXAMPLE/TESTATS/fieldarr2.dats
+++ b/doc/EXAMPLE/TESTATS/fieldarr2.dats
@@ -1,0 +1,85 @@
+//
+// Array of fixed size as field in a record
+//
+// Author: Artyom Shalkhakov (Mar, 2015)
+//
+(* ****** ****** *)
+//
+#include
+"share/atspre_staload.hats"
+//
+staload _ = "prelude/DATS/array.dats"
+//
+(* ****** ****** *)
+//
+typedef vec_t (a:t@ype, n:int) = @{V= @[a][n] }
+typedef vec3_t = vec_t (float, 3)
+//
+typedef entity = @{
+  origin= vec3_t,
+  angles= vec3_t
+}
+//
+(* ****** ****** *)
+
+fun{a:t@ype}
+vec3_make (v: &vec_t (INV(a), 3)? >> _, px: a, py: a, pz: a): void = {
+//
+fun
+aux (v: &(@[INV(a)][3])? >> _, x: a, y: a, z: a): void = {
+//
+prval pf_arr = view@(v)
+var pv = addr@(v)
+//
+prval (pf1_at, pf1_arr) = array_v_uncons {a?} (pf_arr)
+val () = ptr_set<a> (pf1_at | pv, x)
+//
+val () = pv := ptr1_succ<a> (pv)
+prval (pf2_at, pf2_arr) = array_v_uncons {a?} (pf1_arr)
+val () = ptr_set<a> (pf2_at | pv, y)
+//
+val () = pv := ptr1_succ<a> (pv)
+prval (pf3_at, pf3_arr) = array_v_uncons {a?} (pf2_arr)
+val () = ptr_set<a> (pf3_at | pv, z)
+//
+#define :: array_v_cons
+//
+prval pf3_nil = array_v_unnil_nil (pf3_arr)
+prval () = view@(v) := pf1_at :: pf2_at :: pf3_at :: pf3_nil
+//
+} (* end of [aux] *)
+//
+val () = aux (v.V, px, py, pz)
+//
+} (* end of [vec3_make] *)
+
+(* ****** ****** *)
+
+implement main0 () = {
+//
+var b: entity
+//
+val () = array_initize_elt (b.angles.V, i2sz(3), 0.0f)
+val () = vec3_make<float> (b.origin, 0.5f, 0.0f, 1.0f)
+//
+val () = b.origin.V.[0] := 10.0f * b.origin.V.[0]
+val () = b.origin.V.[1] := 4.0f
+val () = b.origin.V.[2] := 180.0f
+//
+val () = println!("origin: ")
+val () = print_float (b.origin.V.[0])
+val () = print_newline ()
+val () = print_float (b.origin.V.[1])
+val () = print_newline ()
+val () = print_float (b.origin.V.[2])
+val () = print_newline ()
+//
+val () = println!("angles: ")
+val () = print_float (b.angles.V.[0])
+val () = print_newline ()
+val () = print_float (b.angles.V.[1])
+val () = print_newline ()
+val () = print_float (b.angles.V.[2])
+val () = print_newline ()
+//
+} (* end of [main0] *)

--- a/libats/DATS/typeval.dats
+++ b/libats/DATS/typeval.dats
@@ -36,6 +36,20 @@
 staload "libats/SATS/typeval.sats"
 
 (* ****** ****** *)
+
+implement
+tieq_to_int1<Z()> (pf | (*void*)) = let
+  prval TIEQZ () = pf in 0
+end // end of [tieq_to_int1<Z()>]
+
+implement
+(t)(*tmp*)
+tieq_to_int1<S(t)> (pf | (*void*)) = let
+  prval TIEQS(pf) = pf in
+  succ(tieq_to_int1<t> (pf | (*void*)))
+end // end of [tieq_to_int1<S(t)>]
+
+(* ****** ****** *)
 //
 implement
 (a)(*tmp*)

--- a/libats/SATS/typeval.sats
+++ b/libats/SATS/typeval.sats
@@ -49,6 +49,16 @@ tieq(type, int) =
 //
 (* ****** ****** *)
 //
+praxi
+lemma_tieq_param {T:type} {n:int} (tieq (T, n)): [n >= 0] void
+//
+(* ****** ****** *)
+
+fun{N:type
+} tieq_to_int1 {n:int} (tieq (N, n) | (*void*)): int(n)
+
+(* ****** ****** *)
+//
 fun
 {a:vt0p}
 {t:type}

--- a/src/pats_histaexp.dats
+++ b/src/pats_histaexp.dats
@@ -501,7 +501,8 @@ if isflt then let
 in
 //
 if issin then let
-  val+ list_cons (lhse, _) = lhses in hisexp_tyrecsin (lhse)
+  val+ list_cons (lhse, _) = lhses in
+  hisexp_tyrecsin (lhse)
 end else let
 in
   hisexp_tyrec (knd, lhses)

--- a/src/pats_typerase_staexp.dats
+++ b/src/pats_typerase_staexp.dats
@@ -471,7 +471,12 @@ case knd of
     | list_cons
       (
         lhse, list_nil()
-      ) => hisexp_tyrecsin (lhse)
+      ) => let
+        val+ HSLABELED (_, _, hse) = lhse in
+        case+ hse.hisexp_node of
+        | HSEtyarr _ => hisexp_tyrec (knd, lhses)
+        | _ => hisexp_tyrecsin (lhse)
+      end // end of [list_cons]
     | _(*non-sing*) => hisexp_tyrec (knd, lhses)
   end // end of [TYRECKINDflt0/1]
 //
@@ -742,7 +747,12 @@ case knd of
     | list_cons
       (
         lhse, list_nil()
-      ) => hisexp_tyrecsin (lhse)
+      ) => let
+        val+ HSLABELED (_, _, hse) = lhse in
+        case+ hse.hisexp_node of
+        | HSEtyarr _ => hisexp_tyrec (knd, lhses)
+        | _ => hisexp_tyrecsin (lhse)
+      end // end of [list_cons]
     | _(*non-sing*) => hisexp_tyrec (knd, lhses)
   end // end of [TYRECKINDflt0/1]
 //


### PR DESCRIPTION
This is in response to issue #90 (the use-case I have in mind is implementing Google's MathFu in ATS2).

Some simple cases of static arrays work. Static arrays cannot be returned from functions (as in C), and they can be put into record fields.

This is half-baked, but it works for the simple case (see the fieldarr2 sample).

On a somewhat unrelated note, I've also added some functions to typeval.