### PR TITLE
Nix build expressions

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -1,9 +1,11 @@
-{
-  stdenv, gmp, tarball, version
+# author: Shea Levy (sheaATshealevyDOTcom)
+{ stdenv
+, gmp
+, tarball
+, version
 }:
 
-stdenv.mkDerivation
-rec {
+stdenv.mkDerivation {
   name = "ATS2-Postiats-${version}";
   src = tarball;
   buildInputs = [ gmp ];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,12 @@
+# author: Shea Levy (sheaATshealevyDOTcom)
 let
   pkgs    = import <nixpkgs> {};
-  version = builtins.readFile ./VERSION;
+
+  version = builtins.head (builtins.match "([^\n]*)\n?" (
+    builtins.readFile ../VERSION
+  ));
 in rec {
-  tarball = pkgs.callPackage ./nix/tarball.nix { inherit version; };
-  build   = pkgs.callPackage ./nix/build.nix { inherit tarball version; };
+  tarball = pkgs.callPackage ./tarball.nix { inherit version; };
+
+  build   = pkgs.callPackage ./build.nix { inherit tarball version; };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,2 @@
+# author: Shea Levy (sheaATshealevyDOTcom)
+(import ./default.nix).tarball

--- a/nix/tarball.nix
+++ b/nix/tarball.nix
@@ -1,35 +1,44 @@
-{
-  stdenv, ats, autoconf, automake, version
+# author: Shea Levy (sheaATshealevyDOTcom)
+{ stdenv
+, ats
+, gmp
+, autoconf
+, automake
+, version
 }:
 
-stdenv.mkDerivation
-rec {
+stdenv.mkDerivation rec {
   name = "ATS2-Postiats-${version}.tgz";
 
-  buildInputs = [ autoconf automake ];
+  buildInputs = [ autoconf automake gmp ];
 
-  src = builtins.filterSource (path: type: (toString path) != (toString ./.git)) ./.;
+  src = builtins.filterSource (path: type:
+    (toString path) != (toString ../.git)
+  ) ../.;
 
   ATSHOME = "${ats}/lib/ats-anairiats-${ats.version}";
+
   ATSHOMERELOC = "ATS-${ats.version}";
 
   configurePhase = ''
-  patchShebangs doc/DISTRIB/ATS-Postiats/autogen.sh
-  export PATSHOME=$PWD
-  make -f codegen/Makefile_atslib
+    patchShebangs doc/DISTRIB/ATS-Postiats/autogen.sh
+    export PATSHOME=$PWD
+    make -f codegen/Makefile_atslib
   '';
  
   buildPhase = ''
-  make -C src all
-  make -C src CBOOT
-  make -C src/CBOOT/prelude
-  make -C src/CBOOT/libc
-  make -C src/CBOOT/libats
-  make -C doc/DISTRIB atspackaging
-  make -C doc/DISTRIB atspacktarzvcf
+    make -C src all
+    make -C src CBOOT
+    make -C src/CBOOT/prelude
+    make -C src/CBOOT/libc
+    make -C src/CBOOT/libats
+    make -C doc/DISTRIB atspackaging
+    make -C doc/DISTRIB atspacktarzvcf
   '';
 
   installPhase = ''
-  mv doc/DISTRIB/${name} $out
+    mv doc/DISTRIB/${name} $out
   '';
+
+  shellHook = "export PATSHOME=$PWD";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+nix/shell.nix


### PR DESCRIPTION
Adds expressions for use with the nix package manager. `shell.nix` in particular is useful with `nix-shell` to build ATS in-tree.