### PR TITLE
undefind macro like Haskell

### DIFF
--- a/prelude/basics_dyn.sats
+++ b/prelude/basics_dyn.sats
@@ -357,6 +357,10 @@ exception GenerallyExn2 of (string, ptr(*data*)) // for unspecified causes
 exception IllegalArgExn of (string) // out of its domain
 //
 (* ****** ****** *)
+// indication that the function is not defined
+exception UndefindExn of ()
+macdef undefind() = $raise UndefindExn()
+(* ****** ****** *)
 
 praxi __vfree_exn (x: exn):<> void // for freeing nullary exception-con
 


### PR DESCRIPTION
Many Haskeller use `undefined` function to use specifying that a function is not implemented.
I would like to use this macro as following:

```
fun unimpl_fun {i:int} (i: int(i)): int(i+1) =
  undefind() // TODO

implement main0 () = {
  val r = unimpl_fun 9
  val () = println! r
}
```