### PR TITLE
automating build distribution process further

### DIFF
--- a/doc/DISTRIB/README
+++ b/doc/DISTRIB/README
@@ -2,7 +2,9 @@
 #
 # HX-2018-03-11:
 # It is assumed that ATS-Anairiats is available!
-# It is also assumed that ATS-Postiats-contrib is available!
+# It is also assumed that ATS-Postiats-contrib is available,
+# and that upstream is the git remote name of the official 
+# ATS-Postriats-contrib repo.
 # Please set PATSCONTRIB to be the path to ATS-Postiats-contrib:
 # export PATSCONTRIB = <the-absolute-path-to-ATS-Postiats-contrib>
 #
@@ -33,22 +35,14 @@ Updating $PATSHOME/VERSION
 # Key Steps for packaging ATS
 #
 ######
+
+Perform prerequisites for setting up ATS2:
   
 git clone https://github.com/githwxi/ATS-Postiats.git
 cd ATS-Postiats
 export PATSHOME=`pwd`
-make -f Makefile_devl
-make -C src -f Makefile CBOOT
-(cp ./bin/*_env.sh.in ./doc/DISTRIB/ATS-Postiats/bin/.)
-(cd ./doc/DISTRIB/ATS-Postiats && sh ./autogen.sh && ./configure)
-make -C src/CBOOT/libc -f Makefile
-make -C src/CBOOT/libats -f Makefile
-make -C src/CBOOT/prelude -f Makefile
-make -C doc/DISTRIB -f Makefile atspackaging
-make -C doc/DISTRIB -f Makefile atspacktarzvcf
-make -C doc/DISTRIB -f Makefile atscontribing
-make -C doc/DISTRIB -f Makefile atscontribtarzvcf
-make -C doc/DISTRIB -f Makefile_inclats tarzvcf
+
+Now run the file in this directoroy ($PATSHOME/doc/DISTRIB), make_distrib.sh.
 
 #######
 #
@@ -57,7 +51,7 @@ make -C doc/DISTRIB -f Makefile_inclats tarzvcf
 #
 #######
 
-ls -al doc/DISTRIB/ATS2-*
+ls -al doc/DISTRIB/ATS2-*.tgz
 
 #######
 #

--- a/doc/DISTRIB/make_distrib.sh
+++ b/doc/DISTRIB/make_distrib.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+ATSCC=$(which atscc)
+if [ -x "$ATSCC" ] ; 
+  then echo "$ATSCC found.";
+  else echo "$ATSCC not found." exit 1;
+fi
+
+GIT=$(which git)
+if [ -x "$GIT" ] ; 
+  then echo "$GIT found.";
+  else echo "$GIT not found." exit 1;
+fi
+
+if [ -z ${PATSHOME+x} ]; 
+  then echo "PATSHOME is unset"; exit 1;
+  else echo "PATSHOME is set to '$PATSHOME'";
+fi
+
+if [ -z ${PATSCONTRIB+x} ]; 
+  then echo "PATSCONTRIB is unset"; exit 1;
+  else echo "PATSCONTRIB is set to '$PATSCONTRIB'";
+fi
+
+cd $PATSCONTRIB && \
+git checkout master && \
+git fetch upstream && \
+git merge upstream/master && \
+cd $PATSHOME && \
+make -f Makefile_devl && \
+make -C src -f Makefile CBOOT  && \
+(cp ./bin/*_env.sh.in ./doc/DISTRIB/ATS-Postiats/bin/.) && \
+(cd ./doc/DISTRIB/ATS-Postiats && sh ./autogen.sh && ./configure) && \
+make -C src/CBOOT/libc -f Makefile && \
+make -C src/CBOOT/libats -f Makefile && \
+make -C src/CBOOT/prelude -f Makefile && \
+make -C doc/DISTRIB -f Makefile atspackaging && \
+make -C doc/DISTRIB -f Makefile atspacktarzvcf && \
+make -C doc/DISTRIB -f Makefile atscontribing && \
+make -C doc/DISTRIB -f Makefile atscontribtarzvcf && \
+make -C doc/DISTRIB -f Makefile_inclats tarzvcf && \
+ls -al doc/DISTRIB/ATS2-*.tgz
+


### PR DESCRIPTION
This is just to make things a little quicker.

Also, a couple of build issues I noticed. The first is the following (ATS2-Postiats-include has a different version)

```
$ ls -al ATS2-* .tgz                                                                                                                  
-rw-r--r--  1 brandon brandon 11191716 Mar 17 20:13 ATS2-Postiats-0.3.10.tgz                                                                                                        
-rw-r--r--  1 brandon brandon    63812 Mar 17 20:13 ATS2-Postiats-contrib-0.3.10.tgz                                                                                                
-rw-r--r--  1 brandon brandon   378983 Mar 17 20:13 ATS2-Postiats-include-0.3.9.tgz         
```

The next is that in `.gitignore` there are somethings that aren't being ignored but should be:

```
Untracked files:                                                                                                                                                                    
  (use "git add <file>..." to include in what will be committed)                                                                                                                    
                                                                                                                                                                                    
        doc/DISTRIB/ATS-Postiats-include/patscontrib/GTK/CATS/gdk.cats                                                                                                              
        doc/DISTRIB/ATS-Postiats-include/patscontrib/GTK/CATS/gdk/                                                                                                                  
        doc/DISTRIB/ATS-Postiats-include/patscontrib/GTK/CATS/gtk.cats                                                                                                              
        doc/DISTRIB/ATS-Postiats-include/patscontrib/GTK/CATS/gtk/                                                                                                                  
        doc/DISTRIB/ATS-Postiats-include/patscontrib/glib/CATS/glib-object.cats                                                                                                     
        doc/DISTRIB/ATS-Postiats-include/patscontrib/glib/CATS/glib.cats                                                                                                            
        doc/DISTRIB/ATS-Postiats/libats/ATS2/DATS/fcntainer/array0.dats                                                                                                             
        doc/DISTRIB/ATS-Postiats/libats/ATS2/DATS/fcntainer/integer.dats                                                                                                            
        doc/DISTRIB/ATS-Postiats/libats/ATS2/DATS/fcntainer/intrange.dats                                                                                                           
        doc/DISTRIB/ATS-Postiats/libats/ATS2/DATS/fcntainer/list0.dats                                                                                                              
        doc/DISTRIB/ATS-Postiats/libats/ATS2/DATS/fcntainer/main.dats                                                                                                               
        doc/DISTRIB/ATS-Postiats/libats/ATS2/SATS/fcntainer.sats                                                                                                                    
        doc/DISTRIB/ATS-Postiats/libats/ML/COMPILE/DATS/array0.dats                                                                                                                 
        doc/DISTRIB/ATS-Postiats/libats/ML/COMPILE/DATS/funarray.dats                                                                                                               
        doc/DISTRIB/ATS-Postiats/libats/ML/COMPILE/DATS/funmap.dats                                                                                                                 
        doc/DISTRIB/ATS-Postiats/libats/ML/COMPILE/DATS/hashtblref.dats                                                                                                             
        doc/DISTRIB/ATS-Postiats/libats/ML/COMPILE/DATS/string.dats                                                                                                                 
        doc/DISTRIB/ATS-Postiats/libats/ML/COMPILE/mylibies.hats                                                                                                                    
        doc/DISTRIB/ATS-Postiats/utils/myatscc/BUILD/                                                                                                                               
        doc/DISTRIB/ATS-Postiats/utils/myatscc/DATS/                                                                                                                                
        doc/DISTRIB/ATS-Postiats/utils/myatscc/Makefile                                                                                                                             
        doc/DISTRIB/ATS-Postiats/utils/myatscc/Makefile_build                                                                                                                       
        doc/DISTRIB/ATS-Postiats/utils/myatscc/README                                                                                                                               
        doc/DISTRIB/ATS-Postiats/utils/myatscc/SATS/                                                                                                                                
        doc/DISTRIB/ATS2-Postiats-0.3.10.tgz                                                                                                                                        
        doc/DISTRIB/ATS2-Postiats-0.3.10/                                                                                                                                           
        doc/DISTRIB/ATS2-Postiats-contrib-0.3.10.tgz                                                                                                                                
        doc/DISTRIB/ATS2-Postiats-include-0.3.9.tgz                                                                                                                                 
        doc/DISTRIB/ATS2-Postiats-include-0.3.9/                   
```

I wonder if this can be simplified a bit in the gitignore so to catch all these automatically.