### PR TITLE
Removing `symbol_FUN` and `symbol_MINUSLTGT`

### DIFF
--- a/src/pats_lexing.dats
+++ b/src/pats_lexing.dats
@@ -1721,7 +1721,7 @@ lexing_char_oct
     in
       loop (buf, pred(k), succ(nchr), i)
     end else i
-  val i = loop (buf, k, 2u, 0)
+  val i = loop (buf, k, 3u, 0)
   val c = (i2c)i
 in
   lexing_char_closing (buf, pos, c)
@@ -1742,7 +1742,7 @@ lexing_char_hex
     in
       loop (buf, pred(k), succ(nchr), i)
     end else i
-  val i = loop (buf, k, 3u, 0)
+  val i = loop (buf, k, 2u, 0)
   val c = (i2c)i
 in
   lexing_char_closing (buf, pos, c)

--- a/src/pats_lexing.dats
+++ b/src/pats_lexing.dats
@@ -1721,7 +1721,7 @@ lexing_char_oct
     in
       loop (buf, pred(k), succ(nchr), i)
     end else i
-  val i = loop (buf, k, 3u, 0)
+  val i = loop (buf, k, 2u, 0)
   val c = (i2c)i
 in
   lexing_char_closing (buf, pos, c)
@@ -1742,7 +1742,7 @@ lexing_char_hex
     in
       loop (buf, pred(k), succ(nchr), i)
     end else i
-  val i = loop (buf, k, 2u, 0)
+  val i = loop (buf, k, 3u, 0)
   val c = (i2c)i
 in
   lexing_char_closing (buf, pos, c)

--- a/src/pats_symbol.sats
+++ b/src/pats_symbol.sats
@@ -58,7 +58,6 @@ val symbol_BACKSLASH : symbol // \
 val symbol_BANG : symbol // !
 val symbol_COLONEQ : symbol // := // assign
 val symbol_COLONEQCOLON : symbol // :=: // exhange
-val symbol_FUN: symbol // fun
 //
 val symbol_GT : symbol // >
 val symbol_GTEQ : symbol // >=

--- a/src/pats_symbol.sats
+++ b/src/pats_symbol.sats
@@ -78,7 +78,6 @@ val symbol_LAND : symbol // &&
 val symbol_LOR : symbol // ||
 val symbol_LRBRACKETS : symbol // []
 val symbol_MINUSGT : symbol // ->
-val symbol_MINUSLTGT : symbol // -<>
 val symbol_QMARK : symbol // ?
 val symbol_QMARKBANG : symbol // ?!
 val symbol_TILDE : symbol // ~


### PR DESCRIPTION
`symbol_FUN` and `symbol_MINUSLTGT`, are declared in `pats_symbols.sats` but nowhere implemented (not only not in `pats_symbols.dats`).