### PR TITLE
Floats require integral and/or fractional part

### DIFF
--- a/src/pats_lexing.sats
+++ b/src/pats_lexing.sats
@@ -551,6 +551,8 @@ lexerr_node =
 //
   | LE_FEXPONENT_empty of ()
   | LE_FEXPONENT_missing of () // YD-2018-07-09: fix hex float format.
+  | LE_FINTEGRAL_missing of () // YD-2018-07-10: fix hex float format.
+  | LE_FINTFRAC_missing of () // YD-2018-07-10: fix hex float format.
 //
   | LE_UNSUPPORTED_char of (char)
 // end of [lexerr_node]

--- a/src/pats_lexing_error.dats
+++ b/src/pats_lexing_error.dats
@@ -188,6 +188,16 @@ case+ x.lexerr_node of
     val () = fprintf (out, ": the floating exponent is missing.", @())
     val ((*void*)) = fprint_newline (out)
   }
+| LE_FINTEGRAL_missing () => () where { // YD-2018-07-10: fix hex float format.
+    val () = fprintf (out, ": error(lexing)", @())
+    val () = fprintf (out, ": the floating integral part is missing.", @())
+    val ((*void*)) = fprint_newline (out)
+  }
+| LE_FINTFRAC_missing () => () where { // YD-2018-07-10: fix hex float format.
+    val () = fprintf (out, ": error(lexing)", @())
+    val () = fprintf (out, ": integral or fractional part is missing.", @())
+    val ((*void*)) = fprint_newline (out)
+  }
 | LE_QUOTE_dangling () => () where {
     val () = fprintf (out, ": error(lexing)", @())
     val () = fprintf (out, ": the quote symbol (') is dangling.", @())


### PR DESCRIPTION
No fix was needed for decimal float, as a consequence of already existing rules. Only hexadecimal float was fixed.