### PR TITLE
Fix hex int format

### DIFF
--- a/src/pats_lexing.dats
+++ b/src/pats_lexing.dats
@@ -2753,6 +2753,12 @@ case+ 0 of
     val k2 = testing_intspseq0 (buf, pos)
     val str = lexbufpos_get_strptr1 (buf, pos)
     val str = string_of_strptr (str)
+    val () = if k1 = 0u then {
+      // YD-2018-07-10: fix hex int format.
+      val loc = lexbufpos_get_location (buf, pos)
+      val err = lexerr_make (loc, LE_IDIGITS_empty)
+      val () = the_lexerrlst_add (err)
+    }
   in
     lexbufpos_token_reset (buf, pos, T_INT_hex(str, k2))
   end // end of [_]

--- a/src/pats_lexing.dats
+++ b/src/pats_lexing.dats
@@ -2741,8 +2741,9 @@ case+ 0 of
     testing_fexponent_bin
       (buf, pos) >= 0 => let
       val () = if k1 = 0u then {
+        // YD-2018-07-10: fix hex float format.
         val loc = lexbufpos_get_location (buf, pos)
-        val err = lexerr_make (loc, LE_FINTEGRAL_missing)
+        val err = lexerr_make (loc, LE_FINTFRAC_missing)
         val () = the_lexerrlst_add (err)
       }
   in

--- a/src/pats_lexing.sats
+++ b/src/pats_lexing.sats
@@ -551,7 +551,6 @@ lexerr_node =
 //
   | LE_FEXPONENT_empty of ()
   | LE_FEXPONENT_missing of () // YD-2018-07-09: fix hex float format.
-  | LE_FINTEGRAL_missing of () // YD-2018-07-10: fix hex float format.
   | LE_FINTFRAC_missing of () // YD-2018-07-10: fix hex float format.
 //
   | LE_UNSUPPORTED_char of (char)

--- a/src/pats_lexing.sats
+++ b/src/pats_lexing.sats
@@ -549,6 +549,8 @@ lexerr_node =
 //
   | LE_DIGIT_oct_89 of (char)
 //
+  | LE_IDIGITS_empty of () // YD-2018-07-10: fix hex int format.
+//
   | LE_FEXPONENT_empty of ()
   | LE_FEXPONENT_missing of () // YD-2018-07-09: fix hex float format.
   | LE_FINTFRAC_missing of () // YD-2018-07-10: fix hex float format.

--- a/src/pats_lexing_error.dats
+++ b/src/pats_lexing_error.dats
@@ -178,6 +178,11 @@ case+ x.lexerr_node of
     val () = fprintf (out, ": illegal digit (oct): %c", @(c))
     val ((*void*)) = fprint_newline (out)
   }
+| LE_IDIGITS_empty () => () where { // YD-2018-07-10: fix hex int format.
+    val () = fprintf (out, ": error(lexing)", @())
+    val () = fprintf (out, ": the integer digits is empty.", @())
+    val ((*void*)) = fprint_newline (out)
+  }
 | LE_FEXPONENT_empty () => () where {
     val () = fprintf (out, ": error(lexing)", @())
     val () = fprintf (out, ": the floating exponent is empty.", @())

--- a/src/pats_lexing_error.dats
+++ b/src/pats_lexing_error.dats
@@ -188,11 +188,6 @@ case+ x.lexerr_node of
     val () = fprintf (out, ": the floating exponent is missing.", @())
     val ((*void*)) = fprint_newline (out)
   }
-| LE_FINTEGRAL_missing () => () where { // YD-2018-07-10: fix hex float format.
-    val () = fprintf (out, ": error(lexing)", @())
-    val () = fprintf (out, ": the floating integral part is missing.", @())
-    val ((*void*)) = fprint_newline (out)
-  }
 | LE_FINTFRAC_missing () => () where { // YD-2018-07-10: fix hex float format.
     val () = fprintf (out, ": error(lexing)", @())
     val () = fprintf (out, ": integral or fractional part is missing.", @())


### PR DESCRIPTION
There was a remaining issue with hexadecimal integers as well: the digits sequence cannot be empty neither.

Additionally, `LE_FINTEGRAL_missing` is removed from the previous fix, to keep only `LE_FINTFRAC_missing`, which is simpler and more meaningful to users.