### PR TITLE
atscc2js: flat record selection

### DIFF
--- a/contrib/CATS-atscc2js/DATS/atscc2js_emit.dats
+++ b/contrib/CATS-atscc2js/DATS/atscc2js_emit.dats
@@ -420,7 +420,7 @@ d0e0.d0exp_node of
 | ATSSELcon _ => emit_SELcon (out, d0e0)
 | ATSSELrecsin _ => emit_SELrecsin (out, d0e0)
 | ATSSELboxrec _ => emit_SELboxrec (out, d0e0)
-| ATSSELfltrec _ => emit_text (out, "ATSSELfltrec(...)")
+| ATSSELfltrec _ => emit_SELfltrec (out, d0e0)
 //
 | ATSextfcall
     (_fun, _arg) => {
@@ -586,6 +586,26 @@ val () = emit_RBRACKET (out)
 in
   // nothing
 end // end of [emit_SELboxrec]
+
+(* ****** ****** *)
+
+implement
+emit_SELfltrec
+  (out, d0e) = let
+//
+val-
+ATSSELfltrec
+(d0rec, s0e, id) = d0e.d0exp_node
+//
+val () =
+  emit_d0exp (out, d0rec)
+//
+val () = emit_DOT (out)
+val () = emit_i0de (out, id)
+//
+in
+  // nothing
+end // end of [emit_SELfltrec]
 
 (* ****** ****** *)
 //

--- a/contrib/CATS-parsemit/SATS/catsparse_emit.sats
+++ b/contrib/CATS-parsemit/SATS/catsparse_emit.sats
@@ -180,6 +180,7 @@ fun emit_d0exparg : emit_type (d0explst)
 fun emit_SELcon : emit_type (d0exp)
 fun emit_SELrecsin : emit_type (d0exp)
 fun emit_SELboxrec : emit_type (d0exp)
+fun emit_SELfltrec : emit_type (d0exp)
 
 (* ****** ****** *)
 


### PR DESCRIPTION
This implements flat record selection for `$extype_struct` record types.

Here is an example of usage:

```
typedef domrect = $extype_struct "DOMRect" of {
  x= double, y= double
}
extern
fun getrect (): domrect = "mac#"
%{$
function getrect() { return { x : 1.0, y : 2.0 }; }
%}
fun hello () = {
  val r = getrect ()
  val () = println!(r.x)
  val () = println!(r.y)
}
```
I use this feature in [typesafe-dom](https://github.com/ashalkhakov/typesafe-dom/blob/master/test/bcr.dats#L40) to avoid having to write lots of getters. :)
