### PR TITLE
Minor change to build script.

### DIFF
--- a/doc/EXAMPLE/ATSLIB/libats_ML_array0.dats
+++ b/doc/EXAMPLE/ATSLIB/libats_ML_array0.dats
@@ -74,7 +74,7 @@ val () =
 val xs =
   $list{int}(3, 9, 7, 8, 6, 0, 4, 2, 1, 5)
 //
-val A0 = array0_make_list(g0ofg1_list(xs))
+val A0 = array0_make_list0(g0ofg1_list(xs))
 //
 val () = println! ("A0(bef) = ", A0)
 //
@@ -124,7 +124,7 @@ array0_make_fileref
   val cs =
     fileref_get_file_charlst(inp)
   val A0 =
-    array0_make_list($UN.castvwtp1{list0(char)}(cs))
+    array0_make_list0($UN.castvwtp1{list0(char)}(cs))
   val ((*freed*)) = list_vt_free(cs)
 } (* end of [array0_make_fileref] *)
 

--- a/share/SCRIPT/build_release.sh
+++ b/share/SCRIPT/build_release.sh
@@ -99,12 +99,11 @@ check_version() {
 
 ######
 
-CONFIGURE_AC="${PATSHOME}/doc/DISTRIB/ATS-Postiats/configure.ac"
-AC_INIT_VERSION="AC_INIT([ATS2/Postiats], [${PATSVERSION}], [gmpostiats@gmail.com])"
-
-######
-
 check_ac_init_version() {
+
+    CONFIGURE_AC="${PATSHOME}/doc/DISTRIB/ATS-Postiats/configure.ac"
+    AC_INIT_VERSION="AC_INIT([ATS2/Postiats], [${PATSVERSION}], [gmpostiats@gmail.com])"
+
     if grep -Fxq "$AC_INIT_VERSION" ${CONFIGURE_AC}
     then
 	echo "SUCCESS: Correct Postiats version found in configure.ac!"


### PR DESCRIPTION
The variables "CONFIGURE_AC" and "AC_INIT_VERSION" should be placed within the function "check_ac_init_version" so that PATSHOME is properly set. Otherwise, PATSHOME expands to "". 

While testing the potential release archives, ATS2-Postiats-int-0.3.13.tgz and ATS2-Postiats-gmp-0.3.13.tgz with the tests from doc/EXAMPLE/ATSLIB/ , [doc/EXAMPLE/ATSLIB/libats_ML_array0.dats](https://github.com/githwxi/ATS-Postiats/blob/master/doc/EXAMPLE/ATSLIB/libats_ML_array0.dats) fails to compile due to changes in [libats/ML/SATS/array0.sats](https://github.com/githwxi/ATS-Postiats/blame/master/libats/ML/SATS/array0.sats#L201)

The changes to the test file, doc/EXAMPLE/ATSLIB/libats_ML_array0.dats, reflect previous additions, seen here: https://github.com/githwxi/ATS-Postiats/commit/8f360b05caf3a4b0172c9f9896b4209df21422a7#diff-6c50c67789307afbb8beaaba492826f0R207