### PR TITLE
libatscc2js: fix duplicate function declarations

### DIFF
--- a/contrib/libatscc2js/ATS2-0.3.2/CATS/bool_cats.js
+++ b/contrib/libatscc2js/ATS2-0.3.2/CATS/bool_cats.js
@@ -77,19 +77,11 @@ ats2jspre_neq_bool1_bool1(x, y) { return (x !== y); }
 //
 /* ****** ****** */
 //
-function
-ats2jspre_int2bool0(x)
-  { return (x !== 0 ? true : false) ; }
-function
-ats2jspre_int2bool1(x)
-  { return (x !== 0 ? true : false) ; }
+/** m88: remove dups **/
 //
 /* ****** ****** */
 //
-function
-ats2jspre_bool2int0(x) { return (x ? 1 : 0); }
-function
-ats2jspre_bool2int1(x) { return (x ? 1 : 0); }
+/** m88: remove dups **/
 //
 /* ****** ****** */
 

--- a/contrib/libatscc2js/ATS2-0.3.2/Makefile
+++ b/contrib/libatscc2js/ATS2-0.3.2/Makefile
@@ -179,29 +179,31 @@ CATS/HTTP/Ajax/Ajax_cats.js \
 CATS/HTML/canvas-2d/canvas2d_cats.js \
 
 libatscc2js_all:: ; \
-$(CAT) >>$(LIBATSCC2JS_ALL_JS) \
-output/DATS/basics_dats.js \
-output/DATS/char_dats.js \
-output/DATS/string_dats.js \
-output/DATS/list_dats.js \
-output/DATS/list_vt_dats.js \
-output/DATS/option_dats.js \
-output/DATS/stream_dats.js \
-output/DATS/stream_vt_dats.js \
-output/DATS/gvalue_dats.js \
-output/DATS/intrange_dats.js \
-output/DATS/JSarray_dats.js \
-output/DATS/reference_dats.js \
-output/DATS/arrayref_dats.js \
-output/DATS/matrixref_dats.js \
-output/DATS/gmatrixref_dats.js \
-output/DATS/funarray_dats.js \
-output/DATS/slistref_dats.js \
-output/DATS/qlistref_dats.js \
-output/DATS/ML/list0_dats.js \
-output/DATS/ML/array0_dats.js \
-output/DATS/ML/option0_dats.js \
-output/DATS/ML/matrix0_dats.js \
+$(PATSOPT) \
+-dd ./DATS/basics.dats \
+-dd ./DATS/char.dats \
+-dd ./DATS/string.dats \
+-dd ./DATS/list.dats \
+-dd ./DATS/list_vt.dats \
+-dd ./DATS/option.dats \
+-dd ./DATS/stream.dats \
+-dd ./DATS/stream_vt.dats \
+-dd ./DATS/gvalue.dats \
+-dd ./DATS/intrange.dats \
+-dd ./DATS/JSarray.dats \
+-dd ./DATS/reference.dats \
+-dd ./DATS/arrayref.dats \
+-dd ./DATS/matrixref.dats \
+-dd ./DATS/gmatrixref.dats \
+-dd ./DATS/funarray.dats \
+-dd ./DATS/slistref.dats \
+-dd ./DATS/qlistref.dats \
+-dd ./DATS/ML/list0.dats \
+-dd ./DATS/ML/array0.dats \
+-dd ./DATS/ML/option0.dats \
+-dd ./DATS/ML/matrix0.dats \
+| $(ATSCC2JS) -i \
+>>$(LIBATSCC2JS_ALL_JS) 
 
 ######
 #

--- a/contrib/libatscc2js/CATS/bool_cats.js
+++ b/contrib/libatscc2js/CATS/bool_cats.js
@@ -77,19 +77,11 @@ ats2jspre_neq_bool1_bool1(x, y) { return (x !== y); }
 //
 /* ****** ****** */
 //
-function
-ats2jspre_int2bool0(x)
-  { return (x !== 0 ? true : false) ; }
-function
-ats2jspre_int2bool1(x)
-  { return (x !== 0 ? true : false) ; }
+/* m88: remove dups */
 //
 /* ****** ****** */
 //
-function
-ats2jspre_bool2int0(x) { return (x ? 1 : 0); }
-function
-ats2jspre_bool2int1(x) { return (x ? 1 : 0); }
+/* m88: remove dups */
 //
 /* ****** ****** */
 


### PR DESCRIPTION
This request consists of two changes:
1) Use `patsopt` instead of file concatenation to create `libatscc2js_all.js`:  fixes a namespace collision (previously, `_ats2jspre_list_loop_3` would be declared twice, possibly causing bugs); duplicate names also interfere with JS tooling. 
2) Remove duplicate functions from bool_cats.js: duplicate names interfere with JS tooling.
     