### PR TITLE
Update main.atxt

### DIFF
--- a/doc/BOOK/INT2PROGINATS/CHAP_DEPDTREF/main.atxt
+++ b/doc/BOOK/INT2PROGINATS/CHAP_DEPDTREF/main.atxt
@@ -693,12 +693,6 @@ match one of the following three patterns:
 
 <listitem>
 #para("
-#dyncode("(list_nil(), list_nil())")
-")
-</listitem>
-
-<listitem>
-#para("
 #dyncode("(list_cons _, list_nil())")
 ")
 </listitem>
@@ -706,6 +700,12 @@ match one of the following three patterns:
 <listitem>
 #para("
 #dyncode("(list_nil(), list_cons _)")
+")
+</listitem>
+
+<listitem>
+#para("
+#dyncode("(list_nil(), list_nil())")
 ")
 </listitem>
 


### PR DESCRIPTION
The following paragraph says:

> Given that xs and ys are of the same length, the typechecker can readily infer that (xs, ys) cannot match either of the **first** two patterns.

Emphasis being mine.

I have reordered the bulleted list to reflect what is stated in the paragraph.