### PR TITLE
Fix negation in effects list

### DIFF
--- a/src/pats_parsing_base.dats
+++ b/src/pats_parsing_base.dats
@@ -413,7 +413,7 @@ tok.token_node of
     val ent2 = p_effi0de (buf, bt, err)
   in
     if err = err0 then
-      e0fftag_cst (0, ent2) else tokbuf_set_ntok_null (buf, n0)
+      e0fftag_cst (1, ent2) else tokbuf_set_ntok_null (buf, n0)
     // end of [if]
   end
 //


### PR DESCRIPTION
I noticed while trying to use the `~` operator on an effect that it didn't seem to be working. Lookgin at `p_e0fftag`, I noticed that `0` was being passed to `e0fftag_cst` in both the `T_BANG` and `T_TILDE` cases.

You can observe the change in behaviour with the example program:

```ats
fun f .<>. ():<1,~all> void = ()

val (_) = $showtype f

implmnt main0 () = ()
```

If you use a compile before this PR, you see `eff=S2EFFset(1)`:

```
cpm@nyx ~/src/ATS-Postiats : neg-effects % PATSHOME=~/local/lib/ats2-postiats-0.4.0 ~/local/bin/patsopt -tc -d test0.dats
**SHOWTYPE[UP]**(/home/cpm/src/ATS-Postiats/test0.dats: 57(line=5, offs=21) -- 58(line=5, offs=22)): S2Efun(FUN; lin=0; eff=S2EFFset(1); npf=-1; ; S2Ecst(void)): S2RTbas(S2RTBASimp(0; type))
```

After this change, it's `eff=S2EFFset(0)`:

```
% PATSHOME=~/src/ATS-Postiats ~/src/ATS-Postiats/bin/patsopt -tc -d test0.dats  
**SHOWTYPE[UP]**(/home/cpm/src/ATS-Postiats/test0.dats: 57(line=5, offs=21) -- 58(line=5, offs=22)): S2Efun(FUN; lin=0; eff=S2EFFset(0); npf=-1; ; S2Ecst(void)): S2RTbas(S2RTBASimp(0; type))
```

I have also put together a change for the ATS-Postiats-test repository. I'll link it here after I upload it.
