### PR TITLE
Fix for lexing character escape sequences

### DIFF
--- a/prelude/basics_sta.sats
+++ b/prelude/basics_sta.sats
@@ -132,7 +132,7 @@ uchar_int_t0ype (c:int) = uchar_t0ype
 stadef uchar = uchar_t0ype // shorthand
 stadef uchar = uchar_int_t0ype // shorthand
 typedef uChar = [c:uint8] uchar (c)
-typedef scharNZ = [c:uint8 | c != 0] uchar(c)
+typedef ucharNZ = [c:uint8 | c != 0] uchar(c)
 //
 (* ****** ****** *)
 

--- a/src/pats_lexing.dats
+++ b/src/pats_lexing.dats
@@ -97,7 +97,7 @@ xdigit_get_val
 case+ 0 of
 | _ when c <= '9' => c - '0'
 | _ when c <= 'F' => 10 + (c - 'A') // HX: 'A' = 10
-| _ when c >= 'f' => 10 + (c - 'a') // HX: 'a' = 10
+| _ when c <= 'f' => 10 + (c - 'a') // HX: 'a' = 10
 | _ (* illegal *) => (0) // HX: default for illegals
 //
 ) (* end of [xdigit_get_val] *)
@@ -1851,7 +1851,7 @@ in
       val () = posincby1 (pos)
       val k = testing_xdigitseq0 (buf, pos)
     in
-      if k = 0u then
+      if k = 0u || k > 2u then
         lexbufpos_lexerr_reset (buf, pos, LE_CHAR_hex)
       else
         lexing_char_hex (buf, pos, k)
@@ -1863,7 +1863,7 @@ in
 *)
       val k = testing_octalseq0 (buf, pos)
     in
-      if k = 0u then
+      if k = 0u || k > 3u then
         lexbufpos_lexerr_reset (buf, pos, LE_CHAR_oct)
       else
         lexing_char_oct (buf, pos, k)

--- a/src/pats_lexing_error.dats
+++ b/src/pats_lexing_error.dats
@@ -143,7 +143,7 @@ case+ x.lexerr_node of
   }
 | LE_CHAR_unclose () => () where {
     val () = fprintf (out, ": error(lexing)", @())
-    val () = fprintf (out, ": the char consant is unclosed.", @())
+    val () = fprintf (out, ": the char constant is unclosed.", @())
     val ((*void*)) = fprint_newline (out)
   }
 | LE_STRING_char_oct () => () where {


### PR DESCRIPTION
I came across several issues with lexing character escape sequences. For example, consider the following program:

```ats
#include "share/atspre_define.hats"
#include "share/atspre_staload.hats"

implement main0 () = let
  val c = '\176'
in
  println! ("The tilde character: ", c);
  println! ("The tilde character: \x7e")
end
```

Compiling and running this program:

```
% PATSHOME=~/local/lib/ats2-postiats-0.4.0 ~/local/bin/patscc -o test1 test1.dats
% ./test1 
The tilde character: �
The tilde character: p
```

Compiling it after this change, you instead get a compiler error about the bad character sequence `'\1760'`:

```
% PATSHOME=~/src/ATS-Postiats ~/src/ATS-Postiats/bin/patscc -o test1 test1.dats 
/home/cpm/src/ATS-Postiats/test1.dats: 110(line=5, offs=11) -- 116(line=5, offs=17): error(lexing): the char format (oct) is incorrect.
/home/cpm/src/ATS-Postiats/test1.dats: 116(line=5, offs=17) -- 118(line=5, offs=19): error(lexing): the char constant is unclosed.
/home/cpm/src/ATS-Postiats/test1.dats: 110(line=5, offs=11) -- 116(line=5, offs=17): error(parsing): the syntactic entity [d0exp] is needed.
/home/cpm/src/ATS-Postiats/test1.dats: 102(line=5, offs=3) -- 105(line=5, offs=6): error(parsing): the keyword [in] is needed.
/home/cpm/src/ATS-Postiats/test1.dats: 96(line=4, offs=22) -- 99(line=4, offs=25): error(parsing): the syntactic entity [d0exp] is needed.
/home/cpm/src/ATS-Postiats/test1.dats: 75(line=4, offs=1) -- 84(line=4, offs=10): error(parsing): the token is discarded.
exit(ATS): uncaught exception: _2home_2cpm_2src_2ATS_2dPostiats_2src_2pats_error_2esats__FatalErrorExn(1025)
```

If you fix the character, giving you the following program, it will then compile:

```
% cat test2.dats 
#include "share/atspre_define.hats"
#include "share/atspre_staload.hats"

implement main0 () = let
  val c = '\176'
in
  println! ("The tilde character: ", c);
  println! ("The tilde character: \x7e")
end
cpm@nyx ~/src/ATS-Postiats : neg-effects % PATSHOME=~/src/ATS-Postiats ~/src/ATS-Postiats/bin/patscc -o test2 test2.dats  
cpm@nyx ~/src/ATS-Postiats : neg-effects % ./test2 
The tilde character: ~
The tilde character: ~
```

I have put together a change for the ATS-Postiats-test repo. I will link it here after I upload it.

This change also includes a small commit that fixes the intended `ucharNZ` definition in `basics_sta.sats`.