### PR TITLE
fix broken Makefiles

### DIFF
--- a/contrib/CATS-atscc2clj/Makefile
+++ b/contrib/CATS-atscc2clj/Makefile
@@ -13,10 +13,6 @@ PATSOPT=$(PATSHOME)/bin/patsopt
 
 ######
 
-all::
-
-######
-
 CATSPARSEMIT=./CATS-parsemit
 
 ######

--- a/contrib/CATS-parsemit/Makefile
+++ b/contrib/CATS-parsemit/Makefile
@@ -13,7 +13,7 @@ all:: DATS_C
 
 ######
 #
-DATS_C:: CATS/catsparse_all_dats.c
+DATS_C: CATS/catsparse_all_dats.c
 #
 ######
 #

--- a/utils/libatsopt/Makefile
+++ b/utils/libatsopt/Makefile
@@ -10,10 +10,6 @@ MAKE=make
 
 ######
 
-copy::
-
-######
-
 build:: ; \
 $(MAKE) -C BUILD -f ../Makefile_build
 

--- a/utils/libatsynmark/Makefile
+++ b/utils/libatsynmark/Makefile
@@ -10,10 +10,6 @@ MAKE=make
 
 ######
 
-copy::
-
-######
-
 build:: ; \
 $(MAKE) -C BUILD -f ../Makefile_build
 


### PR DESCRIPTION
This fixes some the broken Makefiles that kept `C9-ATS2-install-latest.sh`  from being able to run all the way. https://github.com/ats-lang/ats-lang.github.io/issues/8#issuecomment-1368496645

Will in addition need [to fix the paths in that script.](https://github.com/ats-lang/ats-lang.github.io/pull/9)