### PR TITLE
Add Nix flake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -326,4 +326,7 @@ doc/BOOK/ATS2TUTORIAL/CHAP_*/*_atxt.dats
 doc/BOOK/ATS-for-APUE3/apue.3e
 doc/BOOK/ATS-for-APUE3/CHAP_*/main.db
 
+# Nix
+result
+
 ###### end of [.gitignore] ######

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726320982,
+        "narHash": "sha256-RuVXUwcYwaUeks6h3OLrEmg14z9aFXdWppTWPMTwdQw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8f7492cce28977fbf8bd12c72af08b1f6c7c3e49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8f7492cce28977fbf8bd12c72af08b1f6c7c3e49",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Nix flake for ATS2.";
+
+  # nixos-24.05 as of 2024-09-17
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/8f7492cce28977fbf8bd12c72af08b1f6c7c3e49";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      {
+        packages = rec {
+          ats2 = pkgs.ats2;
+          # TODO: build by ourselves for more granular control
+          # ats2 = pkgs.callPackage ./package.nix {};
+          default = ats2;
+        };
+        apps = rec {
+          patsopt = flake-utils.lib.mkApp { 
+            drv = self.packages.${system}.ats2;
+            name = "patsopt";
+          };
+          default = patsopt;
+        };
+      }
+    );
+}


### PR DESCRIPTION
So you can run `patsopt` easily and reproducibly:
```
nix run github:githwxi/ATS-Postiats#patsopt -- --help
```
Or drop into a shell with all the ATS2 tools present:
```
nix shell github:githwxi/ATS-Postiats
```